### PR TITLE
Draft fix #31: Switch DB to be async

### DIFF
--- a/bugwoosh-drafts/issue-31.md
+++ b/bugwoosh-drafts/issue-31.md
@@ -1,0 +1,5 @@
+# Draft fix for #31
+
+Issue: Switch DB to be async
+
+This file is a placeholder created by BugWoosh. Replace it with the real implementation.


### PR DESCRIPTION
Auto-created by BugWoosh for issue #31.

Issue: Switch DB to be async

Branch: `31-switch-db-to-be-async`