### PR TITLE
Draft fix #29: Sets should be able to be searchable by ID

### DIFF
--- a/bugwoosh-drafts/issue-29.md
+++ b/bugwoosh-drafts/issue-29.md
@@ -1,0 +1,5 @@
+# Draft fix for #29
+
+Issue: Sets should be able to be searchable by ID
+
+This file is a placeholder created by BugWoosh. Replace it with the real implementation.


### PR DESCRIPTION
Auto-created by BugWoosh for issue #29.

Issue: Sets should be able to be searchable by ID

Branch: `29-sets-should-be-able-to-be-searchable-by-id`